### PR TITLE
Fix for foreman 1.11 + ruby 2.2

### DIFF
--- a/lib/foreman_noenv/engine.rb
+++ b/lib/foreman_noenv/engine.rb
@@ -9,7 +9,9 @@ module ForemanNoenv
 
     # Add any db migrations
     initializer 'foreman_noenv.load_app_instance_data' do |app|
-      app.config.paths['db/migrate'] += ForemanNoenv::Engine.paths['db/migrate'].existent
+      ForemanNoenv::Engine.paths['db/migrate'].existent.each do |path|
+        app.config.paths['db/migrate'] << path
+      end
     end
 
     initializer 'foreman_noenv.register_plugin', after: :finisher_hook do |_app|


### PR DESCRIPTION
This pull fixes the errors introduced after updated to foreman 1.11, which uses ruby 2.2 and rails 4.1

rake aborted!
NoMethodError: undefined method `+' for #<Rails::Paths::Path:0x00000006d1ce68>
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_noenv-0.0.4/lib/foreman_noenv/engine.rb:12:in`block in class:Engine'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/initializable.rb:30:in `instance_exec'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/initializable.rb:30:in`run'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/initializable.rb:55:in `block in run_initializers'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/initializable.rb:54:in`run_initializers'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/application.rb:300:in `initialize!'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/railtie.rb:194:in`public_send'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/railtie.rb:194:in `method_missing'
/usr/share/foreman/config/environment.rb:5:in`<top (required)>'
/opt/rh/rh-ror41/root/usr/share/gems/gems/polyglot-0.3.4/lib/polyglot.rb:65:in `require'
/opt/rh/rh-ror41/root/usr/share/gems/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:247:in`block in require'
/opt/rh/rh-ror41/root/usr/share/gems/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:232:in `load_dependency'
/opt/rh/rh-ror41/root/usr/share/gems/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:247:in`require'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/application.rb:276:in `require_environment!'
/opt/rh/rh-ror41/root/usr/share/gems/gems/railties-4.1.5/lib/rails/application.rb:379:in`block in run_tasks_blocks'
Tasks: TOP => db:migrate => environment
(See full trace by running task with --trace)
